### PR TITLE
"inRole" returning false after just one iteration

### DIFF
--- a/src/Users/EloquentUser.php
+++ b/src/Users/EloquentUser.php
@@ -203,11 +203,13 @@ class EloquentUser extends Model implements RoleableInterface, PermissibleInterf
     {
         foreach ($this->roles as $instance) {
             if ($role instanceof RoleInterface) {
-                return $instance->getRoleId() === $role->getRoleId();
-            }
-
-            if ($instance->getRoleId() == $role || $instance->getRoleSlug() == $role) {
-                return true;
+                if ($instance->getRoleId() === $role->getRoleId()) {
+                    return true;
+                }
+            } else {
+                if ($instance->getRoleId() == $role || $instance->getRoleSlug() == $role) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
I noticed in the last version v2.0.13 that there is a bug in the function "inRole" in the EloquentUser class.

If the user is assigned two roles (administrator, moderator) and you want to check if the user is in the "moderator" role, the loop exists after one iteration. The second role will never be checked.